### PR TITLE
Add icons displaying available animation categories

### DIFF
--- a/src/components/CharacterSideBar.vue
+++ b/src/components/CharacterSideBar.vue
@@ -22,7 +22,7 @@
         <div class="flex-grow pl-2">
           <span class="text-lg">{{ char.charName + ': ' + char.costumeName }}</span>
         </div>
-        <div class="flex flex-shrink-0 gap-1 pr-2">
+        <div class="flex flex-shrink-0 gap-1 pl-2 pr-2">
           <div
             v-if="char.dating"
             class="w-auto h-6 px-2 bg-blue-500 text-white flex items-center justify-center text-xs font-bold rounded"


### PR DESCRIPTION
Small addition to display banners that have Ultimate or Fated Guest animations.

Here how it looks now (ignore missing icons I did sparse checkout to not download all assets):
<img width="398" height="316" alt="chrome_vMyNWTy4e9" src="https://github.com/user-attachments/assets/daaa624f-2280-424d-a973-af1028722559" />
