### PR TITLE
Adds Layer Selector for Spine Viewer

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -52,12 +52,18 @@
             <option v-for="name in animations" :key="name" :value="name">{{ name }}</option>
           </select>
         </div>
-        <div class="absolute top-14 left-4 lg:hidden z-50">
+        <div class="absolute top-14 left-4 lg:hidden z-50 flex flex-row gap-2">
           <button
             v-show="!overlayActive && store.characters.find(c => c.id === store.selectedCharacterId)?.datingHasNoBg && store.animationCategory === 'dating'"
             @click="store.showDatingBg = !store.showDatingBg"
           >
             <BgToggleIcon :active="store.showDatingBg" />
+          </button>
+          <button
+            v-show="!overlayActive"
+            @click="store.layerSelectionEnabled = !store.layerSelectionEnabled"
+          >
+            <LayerSelectIcon :active="store.layerSelectionEnabled" />
           </button>
         </div>
         <SpineViewer
@@ -119,6 +125,7 @@ import MenuIcon from '@/components/icons/MenuIcon.vue';
 import PauseIcon from '@/components/icons/PauseIcon.vue';
 import PlayIcon from '@/components/icons/PlayIcon.vue';
 import BgToggleIcon from '@/components/icons/BgToggleIcon.vue';
+import LayerSelectIcon from '@/components/icons/LayerSelectIcon.vue';
 
 const store = useCharacterStore()
 

--- a/src/components/SpineViewer.vue
+++ b/src/components/SpineViewer.vue
@@ -16,14 +16,22 @@
       >
         <BgEditIcon />
       </button>
-      <button
-        ref="datingToggleRef"
-        v-show="store.characters.find(c => c.id === store.selectedCharacterId)?.datingHasNoBg && store.animationCategory === 'dating'"
-        @click="store.showDatingBg = !store.showDatingBg"
-        class="w-8 h-8 p-1.5 rounded-md hidden lg:flex items-center justify-center bg-gray-800/70 hover:bg-gray-700/70 text-white transition-colors"
-      >
-        <BgToggleIcon :active="store.showDatingBg" />
-      </button>
+      <div class="flex flex-row gap-2">
+        <button
+          ref="datingToggleRef"
+          v-show="store.characters.find(c => c.id === store.selectedCharacterId)?.datingHasNoBg && store.animationCategory === 'dating'"
+          @click="store.showDatingBg = !store.showDatingBg"
+          class="w-8 h-8 p-1.5 rounded-md hidden lg:flex items-center justify-center bg-gray-800/70 hover:bg-gray-700/70 text-white transition-colors"
+        >
+          <BgToggleIcon :active="store.showDatingBg" />
+        </button>
+        <button
+          @click="store.layerSelectionEnabled = !store.layerSelectionEnabled"
+          class="w-8 h-8 p-1.5 rounded-md hidden lg:flex items-center justify-center bg-gray-800/70 hover:bg-gray-700/70 text-white transition-colors"
+        >
+          <LayerSelectIcon :active="store.layerSelectionEnabled" />
+        </button>
+      </div>
     </div>
     <div ref="viewerWrapper" class="relative w-full h-full">
       <div class="absolute inset-0 overflow-hidden" :style="backgroundContainerStyle">
@@ -100,6 +108,7 @@ import type { SpinePlayerInternal } from '@/types/spine-player-internal'
 
 import BgEditIcon from '@/components/icons/BgEditIcon.vue'
 import BgToggleIcon from '@/components/icons/BgToggleIcon.vue'
+import LayerSelectIcon from '@/components/icons/LayerSelectIcon.vue'
 
 type ResizeHandle = 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
 type SpineSlot = {
@@ -1075,6 +1084,12 @@ watch(() => store.showDatingBg, () => {
   void load()
 })
 
+watch(() => store.layerSelectionEnabled, enabled => {
+  if (!enabled) {
+    store.selectedLayerName = null
+  }
+})
+
 watch(showingMobileOverlay, value => {
   if (value) {
     editingBackground.value = false
@@ -1106,7 +1121,7 @@ function getCameraState() {
 }
 
 function onViewerPointerDown(e: PointerEvent) {
-  if (!player || editingBackground.value) return
+  if (!store.layerSelectionEnabled || !player || editingBackground.value) return
   if (e.button !== 0) return
 
   const bounds = viewerWrapper.value?.getBoundingClientRect()
@@ -1167,7 +1182,7 @@ function drawOverlay() {
   ctx.clearRect(0, 0, canvas.width, canvas.height)
 
   const selectedLayer = store.selectedLayerName
-  if (!selectedLayer) return
+  if (!selectedLayer || !store.layerSelectionEnabled) return
 
   const skeleton = player.skeleton
   if (!skeleton) return

--- a/src/components/SpineViewer.vue
+++ b/src/components/SpineViewer.vue
@@ -59,7 +59,14 @@
           @pointerdown.stop.prevent="event => onResizeHandlePointerDown(handle, event as PointerEvent)"
         />
       </div>
-      <div ref="container" class="absolute inset-0 z-10"></div>
+      <div ref="container" class="absolute inset-0 z-10" @pointerdown="onViewerPointerDown"></div>
+      <canvas ref="overlayCanvas" class="absolute inset-0 z-20 pointer-events-none"></canvas>
+    </div>
+    <div
+      v-if="store.selectedLayerName"
+      class="absolute bottom-6 left-1/2 -translate-x-1/2 bg-gray-900/80 text-white px-4 py-3 rounded-full z-50 pointer-events-none shadow-lg shadow-black/50 text-sm border border-gray-700 backdrop-blur-sm transition-opacity"
+    >
+      Selected Layer: <span class="font-bold text-indigo-400">{{ store.selectedLayerName }}</span>
     </div>
     <input
       type="range"
@@ -80,6 +87,7 @@ import { useCharacterStore } from '@/stores/characterStore'
 import {
   SpinePlayer,
   Vector2,
+  Vector3,
   CameraController,
   OrthoCamera,
   GLTexture,
@@ -99,6 +107,7 @@ type SpineSlot = {
   color?: { a: number }
   darkColor?: { a: number }
   setAttachment?: (attachment: unknown) => void
+  getAttachment?: () => unknown
   attachment?: unknown
 }
 
@@ -110,6 +119,7 @@ const datingToggleRef = ref<HTMLButtonElement | null>(null)
 const backgroundImageWrapperRef = ref<HTMLDivElement | null>(null)
 const backgroundOverlayRef = ref<HTMLDivElement | null>(null)
 const backgroundImageEl = ref<HTMLImageElement | null>(null)
+const overlayCanvas = ref<HTMLCanvasElement | null>(null)
 
 const progress = ref(0)
 const store = useCharacterStore()
@@ -848,6 +858,7 @@ async function load() {
         }
       }
       applyLayerVisibility(player?.skeleton ?? null)
+      drawOverlay()
     },
     success: (p: SpinePlayer) => {
       const skeleton = p.skeleton ?? null
@@ -1071,7 +1082,161 @@ watch(showingMobileOverlay, value => {
   updateCanvasPointerEvents()
 })
 
+function isPointInPolygon(px: number, py: number, vertices: Float32Array): boolean {
+  let inside = false
+  for (let i = 0, j = vertices.length - 2; i < vertices.length; j = i, i += 2) {
+    const xi = vertices[i], yi = vertices[i + 1]
+    const xj = vertices[j], yj = vertices[j + 1]
+    const intersect = ((yi > py) !== (yj > py)) && (px < (xj - xi) * (py - yi) / (yj - yi) + xi)
+    if (intersect) inside = !inside
+  }
+  return inside
+}
+
+function getCameraState() {
+  const renderCam = player?.sceneRenderer?.camera
+  if (!renderCam) return null
+  return {
+    cx: renderCam.position.x,
+    cy: renderCam.position.y,
+    zoom: renderCam.zoom,
+    vw: renderCam.viewportWidth,
+    vh: renderCam.viewportHeight
+  }
+}
+
+function onViewerPointerDown(e: PointerEvent) {
+  if (!player || editingBackground.value) return
+  if (e.button !== 0) return
+
+  const bounds = viewerWrapper.value?.getBoundingClientRect()
+  if (!bounds) return
+  
+  const camState = getCameraState()
+  if (!camState) return
+
+  const screenX = e.clientX - bounds.left
+  const screenY = e.clientY - bounds.top
+
+  const { cx, cy, zoom, vw, vh } = camState
+
+  const nx = (screenX / bounds.width) * 2 - 1
+  const ny = 1 - 2 * (screenY / bounds.height)
+
+  const wx = nx * (vw / 2) * zoom + cx
+  const wy = ny * (vh / 2) * zoom + cy
+
+  const slots = player.skeleton?.drawOrder
+  if (!slots) return
+
+  for (let i = slots.length - 1; i >= 0; i--) {
+    const slot = slots[i] as unknown as SpineSlot
+    if (store.layerVisibility[slot.data.name] === false) continue
+
+    const attachment = slot.getAttachment?.() as any
+    const vertexCount = attachment?.worldVerticesLength ?? 0
+
+    if (vertexCount > 0 && typeof attachment.computeWorldVertices === 'function') {
+      const worldVertices = new Float32Array(vertexCount)
+      attachment.computeWorldVertices(slot, 0, vertexCount, worldVertices, 0, 2)
+      if (isPointInPolygon(wx, wy, worldVertices)) {
+        if (store.selectedLayerName !== slot.data.name) {
+          store.selectedLayerName = slot.data.name
+        } else {
+          store.selectedLayerName = null
+        }
+        return
+      }
+    }
+  }
+  store.selectedLayerName = null
+}
+
+function drawOverlay() {
+  const canvas = overlayCanvas.value
+  if (!canvas || !viewerWrapper.value || !player) return
+
+  const rect = viewerWrapper.value.getBoundingClientRect()
+  if (canvas.width !== rect.width || canvas.height !== rect.height) {
+    canvas.width = rect.width
+    canvas.height = rect.height
+  }
+
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+
+  const selectedLayer = store.selectedLayerName
+  if (!selectedLayer) return
+
+  const skeleton = player.skeleton
+  if (!skeleton) return
+  
+  const slots = skeleton.slots as unknown as SpineSlot[]
+  const slot = slots.find(s => s.data.name === selectedLayer)
+  if (!slot || store.layerVisibility[selectedLayer] === false) return
+
+  const attachment = slot.getAttachment?.() as any
+  const vertexCount = attachment?.worldVerticesLength ?? 0
+  if (vertexCount > 0 && typeof attachment.computeWorldVertices === 'function') {
+    const worldVertices = new Float32Array(vertexCount)
+    attachment.computeWorldVertices(slot, 0, vertexCount, worldVertices, 0, 2)
+
+    const camState = getCameraState()
+    if (!camState) return
+    const { cx, cy, zoom, vw, vh } = camState
+
+    ctx.beginPath()
+    for (let i = 0; i < worldVertices.length; i += 2) {
+       const wx = worldVertices[i]
+       const wy = worldVertices[i+1]
+       
+       const nx = ((wx - cx) / zoom) / (vw / 2)
+       const ny = ((wy - cy) / zoom) / (vh / 2)
+
+       const screenX = (nx + 1) * 0.5 * canvas.width
+       const screenY = (1 - (ny + 1) * 0.5) * canvas.height
+
+       if (i === 0) ctx.moveTo(screenX, screenY)
+       else ctx.lineTo(screenX, screenY)
+    }
+    ctx.closePath()
+    ctx.strokeStyle = '#818cf8' // indigo-400
+    ctx.lineWidth = 2
+    ctx.lineJoin = 'round'
+    ctx.stroke()
+    ctx.fillStyle = 'rgba(79, 70, 229, 0.4)' // indigo-600 with opacity
+    ctx.fill()
+  }
+}
+
+function onKeyDown(e: KeyboardEvent) {
+  if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
+  const key = e.key.toLowerCase()
+
+  if (key === 'h') {
+    if (store.selectedLayerName) {
+      store.layerVisibility[store.selectedLayerName] = false
+      store.hiddenLayerStack.push(store.selectedLayerName)
+      store.selectedLayerName = null
+    }
+  } else if (key === 'u') {
+    if (store.hiddenLayerStack.length > 0) {
+      const last = store.hiddenLayerStack.pop()!
+      store.layerVisibility[last] = true
+      store.selectedLayerName = last
+    }
+  } else if (e.key === 'Escape') {
+    while (store.hiddenLayerStack.length > 0) {
+      const last = store.hiddenLayerStack.pop()!
+      store.layerVisibility[last] = true
+    }
+    store.selectedLayerName = null
+  }
+}
+
 onMounted(() => {
+  window.addEventListener('keydown', onKeyDown)
   ensureResizeObserver()
   if (activeBackgroundSrc.value) {
     setBackgroundSource(activeBackgroundSrc.value)
@@ -1080,6 +1245,7 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  window.removeEventListener('keydown', onKeyDown)
   stopPointerTracking()
   if (resizeObserver && viewerWrapper.value) {
     resizeObserver.unobserve(viewerWrapper.value)

--- a/src/components/icons/LayerSelectIcon.vue
+++ b/src/components/icons/LayerSelectIcon.vue
@@ -1,0 +1,11 @@
+<template>
+  <svg class="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="12 2 2 7 12 12 22 7 12 2" />
+    <polyline points="2 12 12 17 22 12" />
+    <line v-if="!active" x1="4" y1="4" x2="20" y2="20" />
+  </svg>
+</template>
+
+<script setup lang="ts">
+defineProps<{ active: boolean }>()
+</script>

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -43,5 +43,7 @@ export const useCharacterStore = defineStore('characterStore', {
     customBackgroundImage: null as string | null,
     layerNames: [] as string[],
     layerVisibility: {} as Record<string, boolean>,
+    selectedLayerName: null as string | null,
+    hiddenLayerStack: [] as string[],
   }),
 })

--- a/src/stores/characterStore.ts
+++ b/src/stores/characterStore.ts
@@ -43,6 +43,7 @@ export const useCharacterStore = defineStore('characterStore', {
     customBackgroundImage: null as string | null,
     layerNames: [] as string[],
     layerVisibility: {} as Record<string, boolean>,
+    layerSelectionEnabled: false as boolean,
     selectedLayerName: null as string | null,
     hiddenLayerStack: [] as string[],
   }),


### PR DESCRIPTION
This adds a layer selector on the Spine viewer that is enabled by a new button toggle on the top left corner of the viewer. When enabled, the user can click on a layer to select it.

Once a layer is selected, the layer name is displayed on the bottom and the selected layer is outlined. The user can then do the following actions:

1. Press H to hide the layer.
2. Press U to show the last hidden layer.
3. Press Escape to show all hidden layers.

I built this using Antigravity so don't have a lot of details on the technical implementation. Not an expert on Vue, but thought it was a cool feature to add. It's working quite well on my local but I haven't done extensive testing.